### PR TITLE
Fixed big trees not growing

### DIFF
--- a/src/main/java/com/untamedears/realisticbiomes/growth/TreeGrower.java
+++ b/src/main/java/com/untamedears/realisticbiomes/growth/TreeGrower.java
@@ -1,10 +1,12 @@
 package com.untamedears.realisticbiomes.growth;
 
+import com.untamedears.realisticbiomes.PlantManager;
+import com.untamedears.realisticbiomes.RealisticBiomes;
+import com.untamedears.realisticbiomes.model.Plant;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Sapling;
 
 public class TreeGrower extends AgeableGrower {
@@ -74,6 +76,16 @@ public class TreeGrower extends AgeableGrower {
 		return northwest;
 	}
 
+	private static void removeSapling(Block block) {
+		PlantManager manager = RealisticBiomes.getInstance().getPlantManager();
+		Plant plant = manager.getPlant(block);
+		if (plant == null) {
+			return;
+		}
+		manager.deletePlant(plant);
+		block.setType(Material.AIR);
+	}
+
 	/**
 	 * Remove a 2x2 saplings grid if the block is part of one
 	 *
@@ -92,10 +104,10 @@ public class TreeGrower extends AgeableGrower {
 		southwest = northwest.getRelative(BlockFace.SOUTH);
 		southeast = northeast.getRelative(BlockFace.SOUTH);
 
-		northwest.setType(Material.AIR);
-		northeast.setType(Material.AIR);
-		southwest.setType(Material.AIR);
-		southeast.setType(Material.AIR);
+		removeSapling(northwest);
+		removeSapling(northeast);
+		removeSapling(southeast);
+		removeSapling(southwest);
 	}
 
 	private static TreeType remapSaplingToTree(Material mat, boolean big) {
@@ -137,8 +149,7 @@ public class TreeGrower extends AgeableGrower {
 			return;
 		}
 		// Re-Read the block data to make sure it is up to date
-		BlockData currentBlockData = block.getLocation().getBlock().getBlockData();
-		if (!(currentBlockData instanceof Sapling)) {
+		if (!(block.getBlockData() instanceof Sapling)) {
 			return;
 		}
 		Material mat = block.getType();


### PR DESCRIPTION
This fixes #18 

The issue was that the `block.getLocation().getWorld().generateTree(block.getLocation(), type);` was returning false when the saplings were still present. This isn't an issue for normal 1x1 trees because the sapling is removed before the call. However, removing 1 sapling isn't enough for 2x2 trees as they requires 4 saplings.

The solution here is to find the 2x2 area with `findNWSapling(Block block, Material mat)` and then to set all 4 saplings to air.

This does cause a minor issue as PlantManager contains what I assume is a set of `Block` which don't automatically update. As a result RB would later try to grow some of the removed saplings (unsuccessfully because `generateTree()` refused) but would still remove the log.
The solution here is fairly dirty: `BlockData currentBlockData = block.getLocation().getBlock().getBlockData();` is called to fetch the most recent block state from memory.

PS: I just realized that could abuse the aforementioned block fetch:
1. Plant 1 sapling
2. Complete the 2x2 area with other sapling later.
3. The first sapling grows and remove the others. The other plants are still "ticking" even though their saplings are gone.
4. Cut the tree before that happens and replace the saplings.
5. Another big tree will grow when the Plants placed in (2) will be "fully grown" prematurely.

I'm going to fix that issue by making calls `PlantManager.deletePlant()` for each sapling when clearing them.  