### PR TITLE
Prevent extending growth time by too much

### DIFF
--- a/src/main/java/com/untamedears/realisticbiomes/PlantLogicManager.java
+++ b/src/main/java/com/untamedears/realisticbiomes/PlantLogicManager.java
@@ -1,19 +1,16 @@
 package com.untamedears.realisticbiomes;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.inventory.ItemStack;
-
 import com.untamedears.realisticbiomes.growth.ColumnPlantGrower;
 import com.untamedears.realisticbiomes.growth.FruitGrower;
 import com.untamedears.realisticbiomes.growth.VerticalGrower;
 import com.untamedears.realisticbiomes.growthconfig.PlantGrowthConfig;
 import com.untamedears.realisticbiomes.model.Plant;
-
+import java.util.HashSet;
+import java.util.Set;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.civmodcore.api.BlockAPI;
 
 public class PlantLogicManager {
@@ -64,7 +61,7 @@ public class PlantLogicManager {
 						// If not broken at max growth, increase creation time based on number of blocks broken
 						long create = bottomColumnPlant.getCreationTime();
 						bottomColumnPlant.setCreationTime(
-								(long) (create + (growthTime * (blocksBroken / (double) grower.getMaxStage()))));
+								(long) Math.min(System.currentTimeMillis(), create + (growthTime * (blocksBroken / (double) grower.getMaxStage()))));
 					}
 				}
 				updateGrowthTime(bottomColumnPlant, sourceColumn);


### PR DESCRIPTION
Fixes a bug where you can extend growth time by placing sugar cane and breaking it repeatedly. 